### PR TITLE
Updated the setResult function

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,16 +17,15 @@ EventResource.prototype.clientGeneration = true;
 EventResource.prototype.handle = function (ctx, next) {
   var parts = ctx.url.split('/').filter(function(p) { return p; });
 
-  var result = {};
-
   var domain = {
       url: ctx.url
     , parts: parts
     , query: ctx.query
     , body: ctx.body
-    , 'this': result
+    , 'this': {}
+    , result: {}
     , setResult: function(val) {
-      result = val;
+      domain.result = val;
     }
   };
 


### PR DESCRIPTION
When calling setResult(); nothing was set in the http response. By setting the result directly on the domain, the expected result is returned.
